### PR TITLE
Add Downloads Endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test with SPM
     runs-on: macOS-latest    
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_12.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_12.4.app/Contents/Developer
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,4 +17,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: SPM Test
-        run: swift test -c debug --sanitize=thread\
+        run: swift test -c debug --sanitize=thread

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,11 +1,12 @@
 # file options
 
 --symlinks ignore
---swiftversion 5.2
+--swiftversion 5.3
 
 # rules
 --enable isEmpty
 --disable andOperator
+--disable wrapMultilineStatementBraces
 
 # format options
 
@@ -15,6 +16,7 @@
 --decimalgrouping 3,5
 --exponentcase lowercase
 --exponentgrouping disabled
+--extensionacl on-declarations
 --fractiongrouping disabled
 --ifdef no-indent
 --importgrouping testable-top

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "a72c5adce3986ff6b5092ae0464a8f2675087860",
-          "version": "1.2.3"
+          "revision": "ba845ee93d6ea10671e829ebf273b6f7a0c92ef0",
+          "version": "1.2.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/swift-server/swift-backtrace.git",
         "state": {
           "branch": null,
-          "revision": "f2fd8c4845a123419c348e0bc4b3839c414077d5",
-          "version": "1.2.0"
+          "revision": "93b3d9a76454e05379a32a2f3b2a1f5a7794b414",
+          "version": "1.2.1"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "8f4bfa5bc1951440c15710e9e893721aa4b2765c",
-          "version": "1.1.3"
+          "revision": "0141f53dd525706c803b0c20aa8ad36f9ecd45e5",
+          "version": "1.1.5"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
-          "version": "1.4.0"
+          "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
+          "version": "1.4.2"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "43931b7a7daf8120a487601530c8bc03ce711992",
-          "version": "2.25.1"
+          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
+          "version": "2.26.0"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "e5b5d191a80667a14827bfeb0ae4a511f7677942",
-          "version": "1.7.0"
+          "revision": "de1c80ad1fdff1ba772bcef6b392c3ef735f39a6",
+          "version": "1.8.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "d4060ac4d056a48d946298f04968f6f6080cc618",
-          "version": "1.16.2"
+          "revision": "f4736a3b78a2bbe3feb7fc0f33f6683a8c27974c",
+          "version": "1.16.3"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "62bf5083df970e67c886210fa5b857eacf044b7c",
-          "version": "2.10.2"
+          "revision": "bbb38fbcbbe9dc4665b2c638dfa5681b01079bfb",
+          "version": "2.10.4"
         }
       },
       {
@@ -123,8 +123,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
         "state": {
           "branch": null,
-          "revision": "5a352330c09a323e59ebd99afdf4ca3964c217bc",
-          "version": "1.9.1"
+          "revision": "1d28d48e071727f4558a8a4bb1894472abc47a58",
+          "version": "1.9.2"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "bb87dcff4cf6d86d386308b4cb1393cefa4891a4",
-          "version": "4.39.2"
+          "revision": "4ba5c2d2112005e4a07cedb43ec52b47175d67ce",
+          "version": "4.41.3"
         }
       },
       {

--- a/Sources/FirewalkApp/BasicAuth.swift
+++ b/Sources/FirewalkApp/BasicAuth.swift
@@ -50,7 +50,7 @@ struct BasicPathAuthenticator: BasicAuthenticator {
 
     func authenticate(basic: BasicAuthorization, for request: Request) -> EventLoopFuture<Void> {
         guard let username = request.parameters["user", as: String.self],
-            let password = request.parameters["passwd", as: String.self] else {
+              let password = request.parameters["passwd", as: String.self] else {
             return request.eventLoop.makeFailedFuture(Error.invalidRequest)
         }
 

--- a/Sources/FirewalkApp/Compression.swift
+++ b/Sources/FirewalkApp/Compression.swift
@@ -25,21 +25,21 @@
 import Vapor
 
 func createCompressionRoutes(for app: Application) throws {
-    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "brotli") { request -> Response in
+    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "brotli") { _ -> Response in
         let response = Response(status: .permanentRedirect)
         response.headers.replaceOrAdd(name: .location, value: "https://httpbin.org/brotli")
 
         return response
     }
-    
-    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "gzip") { request -> Response in
+
+    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "gzip") { _ -> Response in
         let response = Response(status: .permanentRedirect)
         response.headers.replaceOrAdd(name: .location, value: "https://httpbin.org/gzip")
 
         return response
     }
-    
-    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "deflate") { request -> Response in
+
+    app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "deflate") { _ -> Response in
         let response = Response(status: .permanentRedirect)
         response.headers.replaceOrAdd(name: .location, value: "https://httpbin.org/deflate")
 

--- a/Sources/FirewalkApp/DigestAuth.swift
+++ b/Sources/FirewalkApp/DigestAuth.swift
@@ -42,8 +42,8 @@ func createDigestAuthRoute(for app: Application) throws {
 
     app.on([.GET, .POST, .PUT, .PATCH, .DELETE], "digest-auth", ":qop", ":user", ":passwd") { request -> Response in
         guard let qop = request.parameters["qop", as: String.self],
-            let username = request.parameters["user", as: String.self],
-            let password = request.parameters["passwd", as: String.self] else { return Response(status: .badRequest) }
+              let username = request.parameters["user", as: String.self],
+              let password = request.parameters["passwd", as: String.self] else { return Response(status: .badRequest) }
 
         let response = Response(status: .permanentRedirect)
         response.headers.replaceOrAdd(name: .location, value: "https://httpbin.org/digest-auth/\(qop)/\(username)/\(password)")

--- a/Sources/FirewalkApp/Download.swift
+++ b/Sources/FirewalkApp/Download.swift
@@ -1,0 +1,88 @@
+//
+//  Download.swift
+//
+//  Copyright (c) 2021 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Vapor
+
+func createDownloadRoutes(for app: Application) throws {
+    app.on(.GET, "download", ":count") { request -> Response in
+        guard let totalCount = request.parameters["count", as: Int.self],
+              totalCount <= 10_000_000,
+              totalCount.isMultiple(of: 10) else {
+            return .init(status: .badRequest)
+        }
+        
+        let shouldProduceError = (try? request.query.get(Bool.self, at: "shouldProduceError")) ?? false
+        
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy hh:mm:ss zzz"
+        let lastModified = formatter.string(from: Date(timeIntervalSinceReferenceDate: 0))
+        
+        let response: Response
+        
+        if let range = request.headers.range {
+            let byteCount = range.ranges.reduce(0) { result, value in
+                switch value {
+                case let .start(value):
+                    return result + (totalCount - value)
+                case let .tail(value):
+                    return result + value
+                case let .within(start, end):
+                    return result + (end - start)
+                }
+            }
+            
+            let buffer = request.application.allocator.buffer(repeating: UInt8.random(), count: byteCount)
+            response = Response(status: .partialContent, body: .init(buffer: buffer))
+            response.headers.contentRange = .init(unit: .bytes, range: .within(start: (totalCount - byteCount), end: totalCount))
+        } else {
+            var buffer = request.application.allocator.buffer(repeating: UInt8.random(), count: totalCount)
+            response = Response(body: .init(stream: { writer in
+                var bytesToSend = totalCount
+                let segment = (totalCount / 10)
+                request.eventLoop.scheduleRepeatedTask(initialDelay: .seconds(0), delay: .milliseconds(1)) { task in
+                    guard bytesToSend > 0 else { task.cancel(); _ = writer.write(.end); return }
+                    
+                    if shouldProduceError, bytesToSend < (totalCount / 2) {
+                        task.cancel()
+                        _ = writer.write(.error(URLError(.networkConnectionLost)))
+                        return
+                    }
+
+                    _ = writer.write(.buffer(buffer.readSlice(length: segment)!))
+                    bytesToSend -= segment
+                }
+            }))
+            response.headers.add(name: .acceptRanges, value: "bytes")
+            response.headers.replaceOrAdd(name: .contentLength, value: "\(totalCount)")
+            response.headers.remove(name: .transferEncoding)
+        }
+        
+        response.headers.replaceOrAdd(name: .contentType, value: "application/octet-stream")
+        response.headers.add(name: .lastModified, value: lastModified)
+        
+        return response
+    }
+}

--- a/Sources/FirewalkApp/Images.swift
+++ b/Sources/FirewalkApp/Images.swift
@@ -33,12 +33,4 @@ func createImageRoutes(for app: Application) throws {
 
         return response
     }
-
-    // Vapor doesn't support resume ranges, so forward to original test file.
-    app.on(.GET, "image", "large") { _ -> Response in
-        let response = Response(status: .permanentRedirect)
-        response.headers.replaceOrAdd(name: .location, value: "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5f/HubbleDeepField.800px.jpg/2048px-HubbleDeepField.800px.jpg")
-
-        return response
-    }
 }

--- a/Sources/FirewalkApp/WebSocket.swift
+++ b/Sources/FirewalkApp/WebSocket.swift
@@ -22,8 +22,8 @@
 //  THE SOFTWARE.
 //
 
-import Vapor
 import NIOWebSocket
+import Vapor
 
 func createWebSocketRoutes(for app: Application) throws {
     app.webSocket("websocket") { request, socket in
@@ -50,9 +50,9 @@ func createWebSocketRoutes(for app: Application) throws {
             _ = socket.close(code: .unexpectedServerError)
         }
     }
-    
+
     app.webSocket("websocket", "echo") { request, socket in
-        socket.onBinary { (socket, buffer) in
+        socket.onBinary { socket, buffer in
             request.application.logger.info("Sending echo.")
             socket.send(buffer)
         }
@@ -66,7 +66,7 @@ struct WebSocketOptions: Decodable {
 extension WebSocketErrorCode: Decodable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        
+
         let rawCode = try container.decode(Int.self)
         self = Self(codeNumber: rawCode)
     }
@@ -74,11 +74,9 @@ extension WebSocketErrorCode: Decodable {
 
 extension RoutesBuilder {
     @discardableResult
-    public func webSocket(
-        _ path: PathComponent...,
-        maxFrameSize: WebSocketMaxFrameSize = .`default`,
-        onUpgrade: @escaping (Request, WebSocket) throws -> ()
-    ) -> Route {
+    public func webSocket(_ path: PathComponent...,
+                          maxFrameSize: WebSocketMaxFrameSize = .default,
+                          onUpgrade: @escaping (Request, WebSocket) throws -> Void) -> Route {
         webSocket(path, maxFrameSize: maxFrameSize) { request, socket in
             do {
                 try onUpgrade(request, socket)

--- a/Sources/FirewalkApp/configure.swift
+++ b/Sources/FirewalkApp/configure.swift
@@ -37,6 +37,7 @@ public func configure(_ app: Application) throws {
     try createCompressionRoutes(for: app)
     try createDataRoutes(for: app)
     try createDigestAuthRoute(for: app)
+    try createDownloadRoutes(for: app)
     try createIPRoute(for: app)
     try createImageRoutes(for: app)
     try createInspectionRoutes(for: app)

--- a/Tests/FirewalkTests/AppTests.swift
+++ b/Tests/FirewalkTests/AppTests.swift
@@ -40,7 +40,7 @@ final class AppTests: XCTestCase {
 
         // Then
         XCTAssertEqual(response?.status, .ok)
-        XCTAssertEqual(value?.url, "/get")
+        XCTAssertEqual(value?.url, "http://127.0.0.1:8080/get")
     }
 
     func testPost() throws {
@@ -57,7 +57,7 @@ final class AppTests: XCTestCase {
 
         // Then
         XCTAssertEqual(response?.status, .ok)
-        XCTAssertEqual(value?.url, "/post")
+        XCTAssertEqual(value?.url, "http://127.0.0.1:8080/post")
     }
 
     func testGetWithQueryParameters() throws {
@@ -74,7 +74,7 @@ final class AppTests: XCTestCase {
 
         // Then
         XCTAssertEqual(response?.status, .ok)
-        XCTAssertEqual(value?.url, "/get?one=one&two=two")
+        XCTAssertEqual(value?.url, "http://127.0.0.1:8080/get?one=one&two=two")
         XCTAssertEqual(value?.args, ["one": "one", "two": "two"])
     }
 
@@ -92,7 +92,7 @@ final class AppTests: XCTestCase {
 
         // Then
         XCTAssertEqual(response?.status, .ok)
-        XCTAssertEqual(value?.url, "/get?one=one&two=two")
+        XCTAssertEqual(value?.url, "http://127.0.0.1:8080/get?one=one&two=two")
         XCTAssertEqual(value?.args, ["one": "one", "two": "two"])
     }
 
@@ -112,7 +112,7 @@ final class AppTests: XCTestCase {
 
             // Then
             XCTAssertEqual(response?.status, .ok)
-            XCTAssertEqual(value?.url, "/\(method.rawValue.lowercased())")
+            XCTAssertEqual(value?.url, "http://127.0.0.1:8080/\(method.rawValue.lowercased())")
         }
     }
 
@@ -281,24 +281,6 @@ final class AppTests: XCTestCase {
         // Then
         XCTAssertEqual(response?.status, .found)
         XCTAssertEqual(response?.headers.first(name: .location), "URL")
-    }
-
-    func testThatStreamReturnsAppropriateCount() throws {
-        // Given
-        let app = Application(.testing)
-        defer { app.shutdown() }
-        try configure(app)
-
-        let count = 5
-        var response: XCTHTTPResponse?
-
-        // When
-        try app.test(.GET, "stream/\(count)", into: &response)
-
-        // Then
-        let replies = response?.body.string.components(separatedBy: "}{")
-        XCTAssertEqual(replies?.count, count)
-        XCTAssertEqual(response?.status, .ok)
     }
 }
 


### PR DESCRIPTION
### Issue Link :link:
[Alamofire #3416](https://github.com/Alamofire/Alamofire/issues/3416)

### Goals :soccer:
This PR adds support for a `/download/:count` endpoint that allows for the throttled download of random bytes. This enables the testing of download progress and resume data handling. It also allows for resume data on error testing by passing the `shouldProduceError` query parameter.

### Implementation Details :construction:
This PR adds specific range handling for the `download` endpoint, as well as delaying the response stream slightly to allow for more reliable cancellation and progress handling.

### Testing Details :mag:
No new tests.
