### PR TITLE
Add Support for Multiple image Types

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "ba845ee93d6ea10671e829ebf273b6f7a0c92ef0",
-          "version": "1.2.4"
+          "revision": "0dda95cffcdf3d96ca551e5701efd1661cf31374",
+          "version": "1.2.5"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "0141f53dd525706c803b0c20aa8ad36f9ecd45e5",
-          "version": "1.1.5"
+          "revision": "3bea268b223651c4ab7b7b9ad62ef9b2d4143eb6",
+          "version": "1.1.6"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "6d3ca7e54e06a69d0f2612c2ce8bb8b7319085a4",
-          "version": "2.26.0"
+          "revision": "3be4e0980075de10a4bc8dee07491d49175cfd7a",
+          "version": "2.27.0"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "bbb38fbcbbe9dc4665b2c638dfa5681b01079bfb",
-          "version": "2.10.4"
+          "revision": "07c160b8724ee53a4b776328122be6338ff12bf2",
+          "version": "2.11.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "4ba5c2d2112005e4a07cedb43ec52b47175d67ce",
-          "version": "4.41.3"
+          "revision": "73d57959a96ceca719558e70c320b2f729d2b25b",
+          "version": "4.41.10"
         }
       },
       {

--- a/Sources/FirewalkApp/Images.swift
+++ b/Sources/FirewalkApp/Images.swift
@@ -1,7 +1,7 @@
 //
 //  Images.swift
 //
-//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2021 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -26,11 +26,100 @@ import Vapor
 
 func createImageRoutes(for app: Application) throws {
     app.on(.GET, "image", ":type") { request -> Response in
-        guard let type = request.parameters["type", as: String.self], ["jpeg", "png", "svg", "webp"].contains(type) else { return Response(status: .badRequest) }
+        guard let type = request.parameters["type", as: String.self], let image = Image(rawValue: type) else {
+            return Response(status: .badRequest)
+        }
 
-        let response = Response(status: .permanentRedirect)
-        response.headers.replaceOrAdd(name: .location, value: "https://httpbin.org/image/\(type)")
+        let response = Response(status: .ok)
+        response.headers.contentType = image.contentType
+        response.headers.contentDisposition = .init(.attachment, filename: image.suggestedFilename)
 
+        let imageData = Data(base64Encoded: image.encodedImage)!
+        response.body = .init(data: imageData)
+        
         return response
+    }
+}
+
+private enum Image: String, Decodable {
+    case bmp, jp2, jpeg, gif, heic, heif, pdf, png, tiff, webp
+    
+    var contentType: HTTPMediaType {
+        switch self {
+        case .bmp:
+            return HTTPMediaType(type: "image", subType: "x-ms-bmp")
+        case .jp2:
+            return HTTPMediaType(type: "image", subType: "jp2")
+        case .jpeg:
+            return .jpeg
+        case .gif:
+            return .gif
+        case .heic:
+            return HTTPMediaType(type: "image", subType: "heic")
+        case .heif:
+            return HTTPMediaType(type: "image", subType: "heif")
+        case .pdf:
+            return .pdf
+        case .png:
+            return .png
+        case .tiff:
+            return HTTPMediaType(type: "image", subType: "tiff")
+        case .webp:
+            return HTTPMediaType(type: "image", subType: "webp")
+        }
+    }
+    
+    var encodedImage: String {
+        switch self {
+        case .bmp:
+            return "Qk0eAAAAAAAAABoAAAAMAAAAAQABAAEAGAAAAP8A"
+        case .jp2:
+            return """
+                AAAADGpQICANCocKAAAAFGZ0eXBqcDIgAAAAAGpwMiAAAAAtanAyaAAAABZpaGRyAAAAAQAAAAEAAwcHAAAAAAAPY29scgEAAAAAABA\
+                AAAAAanAyY/9P/1EALwAAAAAAAQAAAAEAAAAAAAAAAAAAAAEAAAABAAAAAAAAAAAAAwcBAQcBAQcBAf9cAA1AQEhIUEhIUEhIUP9SAA\
+                wAAAABAQMEBAAB/2QADgABTFRfSlAyXzIyMP+QAAoAAAAAAB0AAf+T34AIB4CAgICAgICAgICA/9k=
+                """
+        case .jpeg:
+            return """
+                /9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAA\
+                BAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k=
+                """
+        case .gif:
+            return "R0lGODlhAQABAIAAAP///wAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw=="
+        case .heic:
+            return """
+                AAAAGGZ0eXBoZWljAAAAAGhlaWNtaWYxAAABtW1ldGEAAAAAAAAAImhkbHIAAAAAAAAAAHBpY3QAAAAAAAAAAAAAAAAAAAAAACRkaW5\
+                mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAA5waXRtAAAAAAABAAAAOGlpbmYAAAAAAAIAAAAVaW5mZQIAAAAAAQAAaHZjMQ\
+                AAAAAVaW5mZQIAAAEAAgAARXhpZgAAAAAaaXJlZgAAAAAAAAAOY2RzYwACAAEAAQAAANdpcHJwAAAAt2lwY28AAAATY29scm5jbHgAA\
+                gACAAaAAAAAb2h2Y0MBAWAAAACwAAAAAAAe8AD8/fj4AAAPA6AAAQAXQAEMAf//AWAAAAMAsAAAAwAAAwAeLAmhAAEAIkIBAQFgAAAD\
+                ALAAAAMAAAMAHqAggQWcuSRIEuJuBAQNSASiAAEACEQBwGDUYikgAAAAFGlzcGUAAAAAAAAAQAAAAEAAAAAJaXJvdAAAAAAQcGl4aQA\
+                AAAADCAgIAAAAGGlwbWEAAAAAAAAAAQABBYGCA4QFAAAALGlsb2MAAAAARAAAAgABAAAAAQAAAgEAAAA2AAIAAAABAAAB3QAAACQAAA\
+                ABbWRhdAAAAAAAAABqAAAABkV4aWYAAE1NACoAAAAIAAEBEgADAAAAAQABAAAAAAAAAAAAMiYBrx9RH1wAAIvaQ7NuvDTJKZKZKZKZK\
+                8K8K8K8K8K8K8K8+8h9YbnhyPHF8zZ/kV9X
+                """
+        case .heif:
+            return """
+                AAAAGGZ0eXBoZWljAAAAAG1pZjFoZWljAAABKm1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAHBpY3QAXABjADEANQB4ADIAAAAADnBpdG0\
+                AAAAAAAEAAAAiaWxvYwAAAABEQAABAAEAAAAAAUoAAQAAAAAAAAA4AAAAI2lpbmYAAAAAAAEAAAAVaW5mZQIAAAAAAQAAaHZjMQAAAA\
+                CqaXBycAAAAI1pcGNvAAAAcWh2Y0MBBAgAAAAAAAAAAAD/8AD8/fj4AAAPAyAAAQAXQAEMAf//BAgAAAMAn6gAAAMAAP+6AkAhAAEAJ\
+                kIBAQQIAAADAJ+oAAADAAD/oCCBBZbqSSiuAQAAAwABAAADAAEIIgABAAZEAcFxiRIAAAAUaXNwZQAAAAAAAABAAAAAQAAAABVpcG1h\
+                AAAAAAAAAAEAAQKBAgAAAEBtZGF0AAAANCgBrwW4FIPqI0Af91/uf7X9b878787878989898989898989/4UETMJZQNe2nK06cUg1sA=
+                """
+        case .pdf:
+            return """
+                JVBERi0xLgoxIDAgb2JqPDwvUGFnZXMgMiAwIFI+PmVuZG9iagoyIDAgb2JqPDwvS2lkc1szIDAgUl0vQ291bnQgMT4+ZW5kb2JqCjM\
+                gMCBvYmo8PC9QYXJlbnQgMiAwIFI+PmVuZG9iagp0cmFpbGVyIDw8L1Jvb3QgMSAwIFI+Pg==
+                """
+        case .png:
+            return "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+        case .tiff:
+            return "TU0AKgAAAAgAAwEAAAMAAAABAAEAAAEBAAMAAAABAAEAAAERAAMAAAABAAAAAA=="
+        case .webp:
+            return "UklGRhYAAABXRUJQVlA4TAkAAAAvAAAAAIiI/gcA"
+        }
+    }
+    
+    var suggestedFilename: String {
+        "\(rawValue).\(rawValue)"
     }
 }


### PR DESCRIPTION
### Goals :soccer:
This PR replaces the previous redirect to HTTPBin for images with locally decoded minimal images.

### Implementation Details :construction:
This PR adds Base64 encoded minimal images for several images types.

### Testing Details :mag:
None.
