### PR TITLE
Cache Endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,11 @@ jobs:
   macOS:
     name: macOS
     runs-on: firebreak
+    defaults:
+      run:
+        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
@@ -35,7 +38,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-20.04
     container:
-      image: swift:5.5.2-focal
+      image: swift:5.6.1-focal
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,11 @@ jobs:
   release:
     name: Upload Release Artifact
     runs-on: firebreak
+    defaults:
+      run:
+        shell: "/usr/bin/arch -arch arm64e /bin/zsh {0}"
     env: 
-      DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,7 +1,7 @@
 # file options
 
 --symlinks ignore
---swiftversion 5.5
+--swiftversion 5.6
 
 # rules
 --enable isEmpty

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "cbf533073d9a5edfb16c266d14151f69137ba7c9",
-          "version": "1.8.2"
+          "revision": "7a4dfe026f6ee0f8ad741b58df74c60af296365d",
+          "version": "1.9.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/apple/swift-crypto.git",
         "state": {
           "branch": null,
-          "revision": "a8911e0fadc25aef1071d582355bd1037a176060",
-          "version": "2.0.4"
+          "revision": "067254c79435de759aeef4a6a03e43d087d61312",
+          "version": "2.0.5"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/apple/swift-metrics.git",
         "state": {
           "branch": null,
-          "revision": "3edd2f57afc4e68e23c3e4956bc8b65ca6b5b2ff",
-          "version": "2.2.0"
+          "revision": "eadb828f878fed144387e3845866225bb7082c56",
+          "version": "2.3.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "d6e3762e0a5f7ede652559f53623baf11006e17c",
+          "version": "2.39.0"
         }
       },
       {
@@ -105,8 +105,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "6e94a7be32891d1b303a3fcfde8b5bf64d162e74",
-          "version": "1.19.1"
+          "revision": "50c25c132b140e62b45e90b5a76f13ded02c8a46",
+          "version": "1.20.1"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "52a486ff6de9bc3e26bf634c5413c41c5fa89ca5",
-          "version": "2.17.2"
+          "revision": "b5260a31c2a72a89fa684f5efb3054d8725a2316",
+          "version": "2.18.0"
         }
       },
       {
@@ -132,8 +132,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "18e9419cae5049e43ca1e8002ca3cf0449f2c8ed",
-          "version": "4.55.0"
+          "revision": "b05266f863ee93eeff4b6d075364ccc8f81bbc1e",
+          "version": "4.57.0"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "ff8fbce837ef01a93d49c6fb49a72be0f150dac7",
-          "version": "2.3.0"
+          "revision": "e32033ad3c68ebec1b761bc961be7bd56bad02f8",
+          "version": "2.3.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 //
 //  Package.swift
 //

--- a/Sources/Inspection.swift
+++ b/Sources/Inspection.swift
@@ -30,19 +30,19 @@ func createInspectionRoutes(for app: Application) throws {
         let encodedHeaders = try JSONEncoder().encodeAsByteBuffer(query, allocator: app.allocator)
         return Response(status: .ok, headers: HTTPHeaders(query.map { $0 }), body: .init(buffer: encodedHeaders))
     }
-    
+
     @Protected var seenCaches: Set<String> = []
-    
+
     // A version of response-headers used for Cache-Control tests, which adds an older Date to the response the first
     // time it's seen.
     app.on(.GET, "cache") { request -> Response in
         let query = try request.query.decode([String: String].self)
-        
+
         guard let cache = query["Cache-Control"] else { return Response(status: .badRequest) }
-        
+
         let encodedHeaders = try JSONEncoder().encodeAsByteBuffer(query, allocator: app.allocator)
         let response = Response(status: .ok, headers: HTTPHeaders(query.map { $0 }), body: .init(buffer: encodedHeaders))
-        
+
         if seenCaches.contains(cache) {
             $seenCaches.write { $0.remove(cache) }
         } else {
@@ -50,7 +50,7 @@ func createInspectionRoutes(for app: Application) throws {
             let past = Date() - 5
             response.headers.replaceOrAdd(name: .date, value: DateFormatter.rfc1123.string(from: past))
         }
-        
+
         return response
     }
 }

--- a/Sources/Inspection.swift
+++ b/Sources/Inspection.swift
@@ -1,7 +1,7 @@
 //
 //  Inspection.swift
 //
-//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2022 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,42 @@ import Vapor
 func createInspectionRoutes(for app: Application) throws {
     app.on(.GET, "response-headers") { request -> Response in
         let query = try request.query.decode([String: String].self)
-        let encodedHeaders = try JSONEncoder().encodeAsByteBuffer(query, allocator: request.application.allocator)
+        let encodedHeaders = try JSONEncoder().encodeAsByteBuffer(query, allocator: app.allocator)
         return Response(status: .ok, headers: HTTPHeaders(query.map { $0 }), body: .init(buffer: encodedHeaders))
     }
+    
+    @Protected var seenCaches: Set<String> = []
+    
+    // A version of response-headers used for Cache-Control tests, which adds an older Date to the response the first
+    // time it's seen.
+    app.on(.GET, "cache") { request -> Response in
+        let query = try request.query.decode([String: String].self)
+        
+        guard let cache = query["Cache-Control"] else { return Response(status: .badRequest) }
+        
+        let encodedHeaders = try JSONEncoder().encodeAsByteBuffer(query, allocator: app.allocator)
+        let response = Response(status: .ok, headers: HTTPHeaders(query.map { $0 }), body: .init(buffer: encodedHeaders))
+        
+        if seenCaches.contains(cache) {
+            $seenCaches.write { $0.remove(cache) }
+        } else {
+            $seenCaches.write { $0.insert(cache) }
+            let past = Date() - 5
+            response.headers.replaceOrAdd(name: .date, value: DateFormatter.rfc1123.string(from: past))
+        }
+        
+        return response
+    }
+}
+
+extension DateFormatter {
+    fileprivate static let rfc1123: DateFormatter = {
+        let formatter = DateFormatter()
+        let enUSPosixLocale = Locale(identifier: "en_US_POSIX")
+        formatter.locale = enUSPosixLocale
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss z"
+        formatter.calendar = Calendar(identifier: .gregorian)
+        return formatter
+    }()
 }

--- a/Sources/Inspection.swift
+++ b/Sources/Inspection.swift
@@ -1,5 +1,5 @@
 //
-//  Inspection.swift
+//  Protected.swift
 //
 //  Copyright (c) 2022 Alamofire Software Foundation (http://alamofire.org/)
 //

--- a/Sources/Protected.swift
+++ b/Sources/Protected.swift
@@ -1,0 +1,137 @@
+//
+//  Inspection.swift
+//
+//  Copyright (c) 2022 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import Foundation
+
+private protocol Lock {
+    func lock()
+    func unlock()
+}
+
+extension Lock {
+    /// Executes a closure returning a value while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    ///
+    /// - Returns:           The value the closure generated.
+    func around<T>(_ closure: () throws -> T) rethrows -> T {
+        lock(); defer { unlock() }
+        return try closure()
+    }
+
+    /// Execute a closure while acquiring the lock.
+    ///
+    /// - Parameter closure: The closure to run.
+    func around(_ closure: () throws -> Void) rethrows {
+        lock(); defer { unlock() }
+        try closure()
+    }
+}
+
+#if os(Linux) || os(Windows)
+
+extension NSLock: Lock {}
+
+#endif
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+/// An `os_unfair_lock` wrapper.
+final class UnfairLock: Lock {
+    private let unfairLock: os_unfair_lock_t
+
+    init() {
+        unfairLock = .allocate(capacity: 1)
+        unfairLock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        unfairLock.deinitialize(count: 1)
+        unfairLock.deallocate()
+    }
+
+    fileprivate func lock() {
+        os_unfair_lock_lock(unfairLock)
+    }
+
+    fileprivate func unlock() {
+        os_unfair_lock_unlock(unfairLock)
+    }
+}
+#endif
+
+/// A thread-safe wrapper around a value.
+@propertyWrapper
+@dynamicMemberLookup
+final class Protected<T> {
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    private let lock = UnfairLock()
+    #elseif os(Linux) || os(Windows)
+    private let lock = NSLock()
+    #endif
+    private var value: T
+
+    init(_ value: T) {
+        self.value = value
+    }
+
+    /// The contained value. Unsafe for anything more than direct read or write.
+    var wrappedValue: T {
+        get { lock.around { value } }
+        set { lock.around { value = newValue } }
+    }
+
+    var projectedValue: Protected<T> { self }
+
+    init(wrappedValue: T) {
+        value = wrappedValue
+    }
+
+    /// Synchronously read or transform the contained value.
+    ///
+    /// - Parameter closure: The closure to execute.
+    ///
+    /// - Returns:           The return value of the closure passed.
+    func read<U>(_ closure: (T) throws -> U) rethrows -> U {
+        try lock.around { try closure(self.value) }
+    }
+
+    /// Synchronously modify the protected value.
+    ///
+    /// - Parameter closure: The closure to execute.
+    ///
+    /// - Returns:           The modified value.
+    @discardableResult
+    func write<U>(_ closure: (inout T) throws -> U) rethrows -> U {
+        try lock.around { try closure(&self.value) }
+    }
+
+    subscript<Property>(dynamicMember keyPath: WritableKeyPath<T, Property>) -> Property {
+        get { lock.around { value[keyPath: keyPath] } }
+        set { lock.around { value[keyPath: keyPath] = newValue } }
+    }
+
+    subscript<Property>(dynamicMember keyPath: KeyPath<T, Property>) -> Property {
+        lock.around { value[keyPath: keyPath] }
+    }
+}


### PR DESCRIPTION
### Goals :soccer:
This PR adds the `cache` endpoint to use with Cache-Control testing.

### Implementation Details :construction:
The `cache` endpoint is the same as `response-headers` but contains special logic to track whether a particular `Cache-Control` value has been request and adjusts the `Date` of the response to make cache testing faster.
