### PR TITLE
Strip Release Builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Build for Release
         run: swift build -c release --arch arm64 --arch x86_64
+      - name: "Strip Artifact"
+        run: strip -rSTx .build/apple/Products/Release/firewalk
       - name: "Zip Artifacts"
         run: zip -r ./firewalk.zip --junk-paths .build/apple/Products/Release/firewalk # Add resources later.
       - name: "Generate Release URL"


### PR DESCRIPTION
### Goals :soccer:
This PR adds a `strip` step to the release build, saving 50+% executable size.

