### PR TITLE
Close Connection on Failed Upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,4 @@ fastlane/test_output
 
 iOSInjectionProject/
 .DS_Store
+.vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,18 @@ All notable changes to this project will be documented in this file.
 - `0.x` Releases - [0.1.0](#010) | [0.2.0](#020) | [0.3.0](#030) | [0.4.0](#040) | [0.5.0](#050)
   [0.6.0](#060) | [0.6.1](#061) | [0.7.0](#070) | [0.8.0](#080) | [0.8.1](#081)
   [0.8.2](#082) | [0.8.3](#083) | [0.9.0](#090) | [0.9.1](#091) | [0.10.0](#0100) | [0.10.1](#0101)
-  [0.10.2](#0102)
+  [0.10.2](#0102) | [0.10.3](#01003)
 
 ---
+
+## [0.10.3](https://github.com/Alamofire/Firewalk/releases/tag/0.10.3)
+
+Released on 2023-11-07.
+
+#### Fixed
+
+- Stall when failing an HTTP upgrade.
+  - Fixed by [Jon Shier](https://github.com/jshier) in PR [#34](https://github.com/Alamofire/Firewalk/pull/34).
 
 ## [0.10.2](https://github.com/Alamofire/Firewalk/releases/tag/0.10.2)
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "eab9edff78e8ace20bd7cb6e792ab46d54f59ab9",
-        "version" : "1.18.0"
+        "revision" : "7ece208cd401687641c88367a00e3ea2b04311f1",
+        "version" : "1.19.0"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "d4b580e466c61f82a46d6bcc0b356add388f7ad2",
-        "version" : "4.8.1"
+        "revision" : "f4ef965dadd999f7e4687053153c97b8b320819c",
+        "version" : "4.10.1"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/routing-kit.git",
       "state" : {
-        "revision" : "e0539da5b60a60d7381f44cdcf04036f456cee2f",
-        "version" : "4.8.0"
+        "revision" : "17a7a3facce8285fd257aa7c72d5e480351e7698",
+        "version" : "4.8.2"
       }
     },
     {
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "99d066e29effa8845e4761dd3f2f831edfdf8925",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-log",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
@@ -104,8 +113,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "3db5c4aeee8100d2db6f1eaf3864afdad5dc68fd",
-        "version" : "2.59.0"
+        "revision" : "853522d90871b4b63262843196685795b5008c46",
+        "version" : "2.61.1"
       }
     },
     {
@@ -113,8 +122,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "fb70a0f5e984f23be48b11b4f1909f3bee016178",
-        "version" : "1.19.1"
+        "revision" : "798c962495593a23fdea0c0c63fd55571d8dff51",
+        "version" : "1.20.0"
       }
     },
     {
@@ -122,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "3798fe5f1564f27461390b4f6163f6ddfb21fd2d",
-        "version" : "1.28.0"
+        "revision" : "3bd9004b9d685ed6b629760fc84903e48efec806",
+        "version" : "1.29.0"
       }
     },
     {
@@ -140,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "e7403c35ca6bb539a7ca353b91cc2d8ec0362d58",
-        "version" : "1.19.0"
+        "revision" : "ebf8b9c365a6ce043bf6e6326a04b15589bd285e",
+        "version" : "1.20.0"
       }
     },
     {
@@ -158,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "61c8104bf688439e4f3f793c9d0746f11d9f846a",
-        "version" : "4.84.5"
+        "revision" : "d682e05fdb64c9f7da01af096a73cd11bb7ab755",
+        "version" : "4.86.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -35,7 +35,7 @@ swiftSettings = []
 let package = Package(name: "Firewalk",
                       platforms: [.macOS(.v10_15)],
                       products: [.executable(name: "firewalk", targets: ["firewalk"])],
-                      dependencies: [.package(url: "https://github.com/vapor/vapor.git", from: "4.79.0")],
+                      dependencies: [.package(url: "https://github.com/vapor/vapor.git", from: "4.86.0")],
                       targets: [.executableTarget(name: "firewalk",
                                                   dependencies: [.product(name: "Vapor", package: "vapor")],
                                                   path: "Sources",

--- a/Sources/Methods.swift
+++ b/Sources/Methods.swift
@@ -55,9 +55,23 @@ func createMethodRoutes(for app: Application) throws {
             response.headers.replaceOrAdd(name: .location, value: redirectAddress)
             return response
         case 400..<600:
-            return Response(status: .init(statusCode: code))
+            let response = Response(status: .init(statusCode: code))
+            // NIO stops parsing HTTP when an upgrade is detected, so close the connection.
+            // Remove if NIO / Vapor fixes the issue.
+            if request.headers.contains(name: .upgrade) {
+                 response.headers.connection = .close
+            }
+            
+            return response
         default:
-            return Response(status: .badRequest)
+            let response = Response(status: .badRequest)
+            // NIO stops parsing HTTP when an upgrade is detected, so close the connection.
+            // Remove if NIO / Vapor fixes the issue.
+            if request.headers.contains(name: .upgrade) {
+                 response.headers.connection = .close
+            }
+            
+            return response
         }
     }
 


### PR DESCRIPTION
### Goals :soccer:
This PR works around an underlying SwiftNIO bug where HTTP decoding stops when detecting an HTTP upgrade but then isn't reenabled if that upgrade fails. For now we'll close instead of reusing the connection, but only for failed upgrades.

This PR also updates dependencies and versions to 0.10.3.
