### PR TITLE
More Reliable Byte Response Timing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ All notable changes to this project will be documented in this file.
 - `0.x` Releases - [0.1.0](#010) | [0.2.0](#020) | [0.3.0](#030) | [0.4.0](#040) | [0.5.0](#050)
   [0.6.0](#060) | [0.6.1](#061) | [0.7.0](#070) | [0.8.0](#080) | [0.8.1](#081)
   [0.8.2](#082) | [0.8.3](#083) | [0.9.0](#090) | [0.9.1](#091) | [0.10.0](#0100) | [0.10.1](#0101)
-  [0.10.2](#0102) | [0.10.3](#01003) | [0.10.4](#01004)
+  [0.10.2](#0102) | [0.10.3](#01003) | [0.10.4](#01004) | [0.11.0](#0110) | [0.12.3](#0123)
+
+---
+
+## [0.12.3](https://github.com/Alamofire/Firewalk/releases/tag/0.12.3)
+
+Released on 2026-04-24.
+
+#### Updated
+
+- Timing of byte responses.
+  - Updated by [Jon Shier](https://github.com/jshier) in PR [#41](https://github.com/Alamofire/Firewalk/pull/41).
 
 ---
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5705cc58d9b9afa4d2babf15f7d66158d4f09ff01a8a77583b7ce286df96bd09",
+  "originHash" : "c077f51c63ed04a0ee4e8948e0706107a5eaa1de8e51049cf0aa620e6b3cbc90",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/console-kit.git",
       "state" : {
-        "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
-        "version" : "4.15.2"
+        "revision" : "32ad16dfc7677b927b225595ed18f3debb32f577",
+        "version" : "4.16.0"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "9f542610331815e29cc3821d3b6f488db8715517",
-        "version" : "1.6.0"
+        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
+        "version" : "1.7.0"
       }
     },
     {
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "24ccdeeeed4dfaae7955fcac9dbf5489ed4f1a25",
-        "version" : "1.18.0"
+        "revision" : "5aa1c0d1bc204908df47c2075bdbb39573d05e8d",
+        "version" : "1.19.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "fa308c07a6fa04a727212d793e761460e41049c3",
-        "version" : "4.3.0"
+        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
+        "version" : "4.5.0"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-http-structured-headers.git",
       "state" : {
-        "revision" : "76d7627bd88b47bf5a0f8497dd244885960dde0b",
-        "version" : "1.6.0"
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {
@@ -159,8 +159,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-metrics.git",
       "state" : {
-        "revision" : "f17c111cec972c2a4922cef38cf64f76f7e87886",
-        "version" : "2.8.0"
+        "revision" : "d51c8d13fa366eec807eedb4e37daa60ff5bfdd5",
+        "version" : "2.10.1"
       }
     },
     {
@@ -168,8 +168,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "558f24a4647193b5a0e2104031b71c55d31ff83a",
-        "version" : "2.97.1"
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
       }
     },
     {
@@ -177,8 +177,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "abcf5312eb8ed2fb11916078aef7c46b06f20813",
-        "version" : "1.33.0"
+        "revision" : "5a48717e29f62cb8326d6d42e46b562ca93847a6",
+        "version" : "1.34.0"
       }
     },
     {
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-http2.git",
       "state" : {
-        "revision" : "6d8d596f0a9bfebb925733003731fe2d749b7e02",
-        "version" : "1.42.0"
+        "revision" : "81cc18264f92cd307ff98430f89372711d4f6fe9",
+        "version" : "1.43.0"
       }
     },
     {
@@ -195,8 +195,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "df9c3406028e3297246e6e7081977a167318b692",
-        "version" : "2.36.1"
+        "revision" : "3f337058ccd7243c4cac7911477d8ad4c598d4da",
+        "version" : "2.37.0"
       }
     },
     {
@@ -204,8 +204,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "60c3e187154421171721c1a38e800b390680fb5d",
-        "version" : "1.26.0"
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
       }
     },
     {
@@ -231,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
       "state" : {
-        "revision" : "89888196dd79c61c50bca9a103d8114f32e1e598",
-        "version" : "2.10.1"
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "a8db2dbda8b3cdc8a61bd35128590bd296e85563",
-        "version" : "4.121.3"
+        "revision" : "cfd8f434843ac7850e2d97f46c1aa5ddb906cf1c",
+        "version" : "4.121.4"
       }
     },
     {
@@ -258,8 +258,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "8666c92dbbb3c8eefc8008c9c8dcf50bfd302167",
-        "version" : "2.16.1"
+        "revision" : "90bbbdab3ede12c803cfbe91646f291c092517a3",
+        "version" : "2.16.2"
       }
     }
   ],

--- a/Sources/Data.swift
+++ b/Sources/Data.swift
@@ -81,13 +81,14 @@ func createDataRoutes(for app: Application) throws {
         }
 
         let response = Response(body: .init(stream: { writer in
-            let bytesToSend = Protected(count)
-            request.eventLoop.scheduleRepeatedTask(initialDelay: .seconds(0), delay: .milliseconds(20)) { task in
-                guard bytesToSend.value > 0 else { task.cancel(); _ = writer.write(.end); return }
-
-                _ = writer.write(.buffer(.init(integer: UInt8(bytesToSend.value))))
-                bytesToSend.write { $0 -= 1 }
+            @Sendable
+            func sendByte(_ remaining: Int) {
+                guard remaining > 0 else { _ = writer.write(.end); return }
+                writer.write(.buffer(.init(integer: UInt8(remaining)))).whenComplete { _ in
+                    request.eventLoop.scheduleTask(in: .milliseconds(20)) { sendByte(remaining - 1) }
+                }
             }
+            sendByte(count)
         }))
 
         response.headers.replaceOrAdd(name: .contentType, value: "application/octet-stream")
@@ -103,13 +104,14 @@ func createDataRoutes(for app: Application) throws {
         let reply = try Reply(to: request)
         let encodedReply = try encoder.encodeAsByteBuffer(reply, allocator: app.allocator)
         let response = Response(body: .init(stream: { writer in
-            let payloadsToSend = Protected(count)
-            request.eventLoop.scheduleRepeatedTask(initialDelay: .seconds(0), delay: .milliseconds(20)) { task in
-                guard payloadsToSend.value > 0 else { task.cancel(); _ = writer.write(.end); return }
-
-                _ = writer.write(.buffer(encodedReply))
-                payloadsToSend.write { $0 -= 1 }
+            @Sendable
+            func sendPayload(_ payloadsToSend: Int) {
+                guard payloadsToSend > 0 else { _ = writer.write(.end); return }
+                writer.write(.buffer(encodedReply)).whenComplete { _ in
+                    request.eventLoop.scheduleTask(in: .milliseconds(20)) { sendPayload(payloadsToSend - 1) }
+                }
             }
+            sendPayload(count)
         }))
 
         response.headers.replaceOrAdd(name: .contentType, value: "application/octet-stream")


### PR DESCRIPTION
### Goals :soccer:
This PR updates the `chunked` and `payloads` endpoints to ensure separate parts are only sent after the previous part is received, rather than using a fixed timer.

### Implementation Details :construction:
Payloads are now separated based on when the payload finished sending, rather than a fixed time.

### Testing Details :mag:
None.
